### PR TITLE
Fixed activationEvents Deprecation Warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Bourbon snippets",
   "repository": "https://github.com/MarioAraque/atom-bourbon-snippets.git",
   "license": "MIT",
-  "activationEvents": [
+  "activationCommands": [
     "atom-bourbon-snippets:toggle"
   ],
   "engines": {


### PR DESCRIPTION
Replaced activationEvents by activationCommands because activationEvents is deprecated.
